### PR TITLE
Removing import of rackunit/private/monad.rkt

### DIFF
--- a/tests/rackunit.rkt
+++ b/tests/rackunit.rkt
@@ -139,10 +139,7 @@
 (require/opaque-type TestCase test-case? rackunit)
 (provide TestCase test-case?)
 
-(require/typed
- rackunit/private/monad
- [#:opaque monad monad?])
-(define-type Seed (U #f monad (Object)))
+(define-type Seed (U #f Any (Object)))
 
 (define-type test-suite-handler-down
   (rackunit-test-suite (Option String) (Thunk Any) (Thunk Any) Seed -> Seed))


### PR DESCRIPTION
`rackunit` package does not have rackunit/private/monad.rkt in `Racket 6.10`. 