### PR TITLE
add support for statically typed gtlc variant

### DIFF
--- a/main.rkt
+++ b/main.rkt
@@ -21,6 +21,9 @@
   (command-line
    #:program "schml"
    #:once-any
+   ["--static"
+    "Static varient of lambda calculus" 
+    (cast-representation 'Static)]
    ["--coercions"
     "Select the coercions representation of casts"
     (cast-representation 'Coercions)]
@@ -32,16 +35,20 @@
     (cast-representation '|Type-Based Casts|)]
    [("-R" "--cast-representation")
     cast-rep
-    ("select cast runtime representation"
-     "default: Coercions")
+    ((format "select cast representation: (~a)" (cast-representation)))
     (case cast-rep
-      [("Type-Based") (cast-representation '|Type-Based Casts|)]
-      [("Coercions")  (cast-representation 'Coercions)]
-      [("Hyper-Coercions") (cast-representation 'Hyper-Coercions)]
+      [("Static")
+       (cast-representation 'Static)]
+      [("Type-Based Casts")
+       (cast-representation '|Type-Based Casts|)]
+      [("Coercions")
+       (cast-representation 'Coercions)]
+      [("Hyper-Coercions")
+       (cast-representation 'Hyper-Coercions)]
       [else (error 'schml "unrecognized cast representation: ~a" cast-rep)])]
    #:once-each
    [("--check-asserts")
-    "Compile coded with assertions"
+    ((format "Compile coded with assertions (~a)" (check-asserts?)))
     (check-asserts? #t)]
    [("--assert-statically-typed")
     "Raise an error unless the program is statically typed"

--- a/src/casts/interpret-casts-common.rkt
+++ b/src/casts/interpret-casts-common.rkt
@@ -272,7 +272,15 @@ TODO write unit tests
          #:dyn-mvec-ref [dyn-mvec-ref  : Dyn-MVec-Ref-Type]
          #:dyn-mvec-set [dyn-mvec-set! : Dyn-MVec-Set-Type]
          #:dyn-fn-app   [dyn-fn-app    : Dyn-Fn-App-Type]
-         #:dyn-tup-prj  [dyn-tup-prj   : Dyn-Tup-Prj-Type])
+         #:dyn-tup-prj  [dyn-tup-prj   : Dyn-Tup-Prj-Type]
+         ;; These are node that may get compiled differently for static
+         #:mbox         [mbox : (CoC3-Expr Schml-Type -> CoC3-Expr) Mbox]
+         #:stc-mbox-ref [stc-mbox-ref : (CoC3-Expr -> CoC3-Expr) Mbox-val-ref]
+         #:stc-mbox-set [stc-mbox-set! : (CoC3-Expr CoC3-Expr -> CoC3-Expr) Mbox-val-set!]
+         #:mvec         [mvec : (CoC3-Expr CoC3-Expr Schml-Type -> CoC3-Expr) Mvector]
+         #:stc-mvec-ref [stc-mvec-ref : (CoC3-Expr CoC3-Expr -> CoC3-Expr) Mvector-val-ref]
+         #:stc-mvec-set [stc-mvec-set! : (CoC3-Expr CoC3-Expr CoC3-Expr -> CoC3-Expr) Mvector-val-set!]
+         #:mvec-len     [mvec-len : (CoC3-Expr -> CoC3-Expr) Mvector-length])
   : (C0-Expr -> CoC3-Expr) 
   ;; map the pass through lists of expressions
   (: recur* (C0-Expr* -> CoC3-Expr*))
@@ -358,16 +366,19 @@ TODO write unit tests
       ;; Long-Term TODO: Why does the name ove these change?
       ;; Does their semantics change?
       [(Mvector-ref (app recur e1) (app recur e2))
-       (Mvector-val-ref e1 e2)]
+       (stc-mvec-ref e1 e2)]
       [(Mvector-set! (app recur e1) (app recur e2) (app recur e3))
-       (Mvector-val-set! e1 e2 e3)]
+       (stc-mvec-set! e1 e2 e3)]
       [(Munbox (app recur e))
-       (Mbox-val-ref e)]
+       (stc-mbox-ref e)]
       [(Mbox-set! (app recur e1) (app recur e2))
-       (Mbox-val-set! e1 e2)]
-      [(Mvector-length e) (Mvector-length (recur e))]
-      [(Mbox (app recur e) t) (Mbox e t)]
-      [(Mvector (app recur e1) (app recur e2) t) (Mvector e1 e2 t)]      
+       (stc-mbox-set! e1 e2)]
+      [(Mvector-length (app recur e)) 
+       (mvec-len e)]
+      [(Mbox (app recur e) t)
+       (mbox e t)]
+      [(Mvector (app recur e1) (app recur e2) t)
+       (mvec e1 e2 t)]      
       ;; While tuples don't get any special attention in this pass
       ;; dynamic tuple projection needs to get dusugared
       [(Create-tuple e*) (Create-tuple (recur* e*))]

--- a/src/casts/interpret-casts-with-error.rkt
+++ b/src/casts/interpret-casts-with-error.rkt
@@ -1,0 +1,73 @@
+#lang typed/racket/base
+#| This pass implements casts by error whenever anything that is non-static exists.
+   It is used to implement a static varient of the GTLC that relies on as much
+   of the same machinery of as the gradual varients as possible. 
+|#
+(require
+ racket/match
+ "../language/cast0.rkt"
+ "../language/cast-or-coerce3.rkt"
+ "./interpret-casts-common.rkt")
+(provide interpret-casts/error)
+
+(: interpret-casts/error : -> (C0-Expr -> CoC3-Expr))
+(define (interpret-casts/error)
+  (make-map-expr
+   #:compile-cast compile-cast/error
+   #:compile-lambda
+   (lambda ([f* : Uid*] [e : CoC3-Expr])
+     (Lambda f* (Castable #f e)))
+   #:compile-app App-Fn 
+   #:pbox-ref Unguarded-Box-Ref
+   #:pbox-set Unguarded-Box-Set!
+   #:pvec-ref Unguarded-Vect-Ref
+   #:pvec-set Unguarded-Vect-Set!
+   #:pvec-len Unguarded-Vect-length
+   ;; Override all of monotonic with regular reference types
+   #:mbox
+   (λ ([v : CoC3-Expr] [t : Schml-Type])
+     (Unguarded-Box v))
+   #:mbox-ref
+   (λ ([a : CoC3-Expr] [t2 : CoC3-Expr])
+     (Unguarded-Box-Ref a))
+   #:mbox-set
+   (λ ([a : CoC3-Expr] [v : CoC3-Expr] [t1 : CoC3-Expr])
+     (Unguarded-Box-Set! a v))
+   #:stc-mbox-ref Unguarded-Box-Ref
+   #:stc-mbox-set Unguarded-Box-Set!
+   #:mvec
+   (λ ([v : CoC3-Expr] [s : CoC3-Expr] [t : Schml-Type])
+     (Unguarded-Vect v s))
+   #:mvec-ref
+   (λ ([a : CoC3-Expr][i : CoC3-Expr][t2 : CoC3-Expr])
+     (Unguarded-Vect-Ref a i))
+   #:mvec-set
+   (λ ([a : CoC3-Expr] [i : CoC3-Expr] [v : CoC3-Expr] [t1 : CoC3-Expr])
+     (Unguarded-Vect-Set! a i v))
+   #:mvec-len Unguarded-Vect-length 
+   #:stc-mvec-ref Unguarded-Vect-Ref
+   #:stc-mvec-set Unguarded-Vect-Set!
+   
+   #:dyn-pbox-ref    (err 'dyn-pbox-ref)
+   #:dyn-pbox-set    (err 'dyn-pbox-set!)
+   #:dyn-pvec-ref    (err 'dyn-pvec-ref)
+   #:dyn-pvec-set    (err 'dyn-pvec-set!)
+   #:dyn-pvec-len    (err 'dyn-pvec-len)
+   #:dyn-mbox-ref    (err 'dyn-mbox-ref)
+   #:dyn-mbox-set    (err 'dyn-mbox-set!)
+   #:dyn-mvec-ref    (err 'dyn-mvec-ref)
+   #:dyn-mvec-set    (err 'dyn-mvec-set!)
+   #:dyn-fn-app      (err 'dyn-fn-app)
+   #:dyn-tup-prj     (err 'dyn-tup-prj)))
+
+  (define ((err sym) . a)
+    (error 'interpret-casts/error
+           "~a: used in supposedly static code"
+           sym))
+  (define (compile-cast/error v t1 t2 l [mt : CoC3-Expr ZERO-EXPR]
+                              #:t1-not-dyn [t1-not-dyn #f]
+                              #:t2-not-dyn [t2-not-dyn #f])
+    (error 'interpret-casts/error
+           "compile-cast: used in supposedly static code"))
+
+

--- a/src/casts/interpret-casts.rkt
+++ b/src/casts/interpret-casts.rkt
@@ -10,7 +10,7 @@
  "interpret-casts-with-type-based-casts.rkt"
  "interpret-casts-with-coercions.rkt"
  "interpret-casts-with-hyper-coercions.rkt"
- )
+ "interpret-casts-with-error.rkt")
 
 (provide
  interpret-casts
@@ -26,15 +26,13 @@
   
   (parameterize ([cast-runtime-code-bindings '()]
                  [current-unique-counter next-unique])
+
     (define ic-expr! : (C0-Expr -> CoC3-Expr)
       (case (cast-representation) 
         [(|Type-Based Casts|) (interpret-casts/type-based-casts)]
         [(Coercions) (interpret-casts/coercions)]
-        [(Hyper-Coercions)
-         #;(error 'uncomment-include/hyper-coercions)
-         (interpret-casts/hyper-coercions)]
-        [(Static) (error 'todo)]
-        [else (error 'todo)]))
+        [(Hyper-Coercions) (interpret-casts/hyper-coercions)]
+        [(Static) (interpret-casts/error)]))
     
     (define new-e (ic-expr! e))
 

--- a/src/configuration.rkt
+++ b/src/configuration.rkt
@@ -8,7 +8,8 @@
   (make-parameter 'Lazy-D))
 
 ;; How casts are represented
-(define-type Cast-Representation (U '|Type-Based Casts| 'Coercions 'Hyper-Coercions))
+(define-type Cast-Representation
+  (U '|Type-Based Casts| 'Coercions 'Hyper-Coercions 'Static))
 (define cast-representation : (Parameterof Cast-Representation)
   (make-parameter 'Coercions))
 


### PR DESCRIPTION
- type checking is completely the same but it is a type-error
  require an implicit cast
- Runtime lowers operation that would have needed runtime protection
  to efficient static representation that isn't possible in
  the gradual semantics
- Hopefully this leads to an easier benchmark comparison story