### PR TITLE
Getting rid of many recursive functions

### DIFF
--- a/benchmark/micro/gen_mono_microbench.sh
+++ b/benchmark/micro/gen_mono_microbench.sh
@@ -65,24 +65,21 @@ main()
     local v="$RETURN"
     echo "(define r : (MRef (Tuple $t)) (mbox (tuple $v)))" > mono.schml
 
+    echo "(define sum : (MRef Int) (mbox 0))" >> mono.schml
+    
     create_gradual $n 1 "Dyn" "Int"
     t="$RETURN"
     echo "(define r0 (: r (MRef (Tuple $t))))" >> mono.schml
     
     local j i
     for ((i=1;i<=n;i++)); do
+	j=$(($i - 1))
+	echo "(mbox-set! sum (+ (tuple-proj (munbox r$j) $i) (munbox sum)))" >> mono.schml
 	create_gradual $n $(($i + 1)) "Dyn" "Int"
 	t="$RETURN"
-	j=$(($i - 1))
 	echo "(define r$i (: r$j (MRef (Tuple $t))))" >> mono.schml
     done
-
-    echo "(define sum : (MRef Int) (mbox 0))" >> mono.schml
-    echo "(begin " >> mono.schml
-    for ((i=0;i<=n;i++)); do
-	echo "(mbox-set! sum (+ (tuple-proj (munbox r$i) $i) (munbox sum)))" >> mono.schml
-    done
-    echo "(munbox sum))" >> mono.schml
+    echo "(munbox sum)" >> mono.schml
 }
 
 main "$@"

--- a/src/casts/specify-representation.rkt
+++ b/src/casts/specify-representation.rkt
@@ -330,7 +330,7 @@ but a static single assignment is implicitly maintained.
                COERCION-MEDIATING-TAG
                (sr-plus COERCION-TUPLE-ELEMENTS-OFFSET i)))
             (assign$ rtti1 (op$ Array-ref mono-addr MONO-RTTI-INDEX))
-            (assign$ new-val (App-Code cast-label `(,val ,crcn ,mono-addr)))
+            (assign$ new-val (app-code$ cast-label val crcn mono-addr))
             (assign$ rtti2 (op$ Array-ref mono-addr MONO-RTTI-INDEX))
             (If (op$ = rtti1 rtti2)
                 (op$ Array-set! tpl-val i new-val)
@@ -364,8 +364,7 @@ but a static single assignment is implicitly maintained.
                 (sr-tagged-array-ref
                  t2 TYPE-TUPLE-TAG (sr-plus TYPE-TUPLE-ELEMENTS-OFFSET i)))
               (assign$ rtti1 (op$ Array-ref mono-addr MONO-RTTI-INDEX))
-              (assign$ new-val
-                (App-Code cast-label `(,val ,t1a ,t2a ,l ,mono-addr)))
+              (assign$ new-val (app-code$ cast-label val t1a t2a l mono-addr))
               (assign$ rtti2 (op$ Array-ref mono-addr MONO-RTTI-INDEX))
               (If (op$ = rtti1 rtti2)
                   (op$ Array-set! tpl-val i new-val)

--- a/src/casts/specify-representation.rkt
+++ b/src/casts/specify-representation.rkt
@@ -1202,18 +1202,8 @@ but a static single assignment is implicitly maintained.
          (type-tuple-elements-access e i)]
         [(Coerce-Tuple coerce (app recur v) (app recur c))
          (app-code$ (get-coerce-tuple! coerce) v c)]
-        [(Coerce-Tuple-In-Place uid (app recur v) (app recur c) (app recur mono-type))
-         (: invoke-coerce-tuple ((Code-Label Uid) (Var Uid) D0-Expr D0-Expr -> D0-Expr))
-         (define (invoke-coerce-tuple coerce-tuple v c a)
-           (App-Code
-            coerce-tuple
-            (list v c a)))
-         (let ([coerce-tuple (get-coerce-tuple-in-place! uid)])
-           (if (Var? v)
-               (invoke-coerce-tuple coerce-tuple v c mono-type)
-               (begin$
-                 (assign$ tuple-val1 v)
-                 (invoke-coerce-tuple coerce-tuple tuple-val1 c mono-type))))]
+        [(Coerce-Tuple-In-Place coerce (app recur v) (app recur c) (app recur mono-type))
+         (app-code$ (get-coerce-tuple-in-place! coerce) v c mono-type)]
         [(Cast-Tuple-In-Place
           uid (app recur v) (app recur t1) (app recur t2) (app recur lbl)
           (app recur mono-address))

--- a/src/casts/specify-representation.rkt
+++ b/src/casts/specify-representation.rkt
@@ -1205,19 +1205,9 @@ but a static single assignment is implicitly maintained.
         [(Coerce-Tuple-In-Place coerce (app recur v) (app recur c) (app recur mono-type))
          (app-code$ (get-coerce-tuple-in-place! coerce) v c mono-type)]
         [(Cast-Tuple-In-Place
-          uid (app recur v) (app recur t1) (app recur t2) (app recur lbl)
+          cast (app recur v) (app recur t1) (app recur t2) (app recur l)
           (app recur mono-address))
-         (: invoke-cast-tuple
-            ((Code-Label Uid) (Var Uid) D0-Expr D0-Expr D0-Expr D0-Expr
-                              -> D0-Expr))
-         (define (invoke-cast-tuple cast-tuple v t1 t2 lbl a)
-           (App-Code cast-tuple (list v t1 t2 lbl a)))
-         (let ([cast-tuple (get-cast-tuple-in-place! uid)])
-           (if (Var? v)
-               (invoke-cast-tuple cast-tuple v t1 t2 lbl mono-address)
-               (begin$
-                 (assign$ tuple-val1 v)
-                 (invoke-cast-tuple cast-tuple tuple-val1 t1 t2 lbl mono-address))))]
+         (app-code$ (get-cast-tuple-in-place! cast) v t1 t2 l mono-address)]
         [(Cast-Tuple cast (app recur v) (app recur t1) (app recur t2) (app recur l))
          (app-code$ (get-cast-tuple! cast) v t1 t2 l)]
         [(Make-Tuple-Coercion mk-crcn (app recur t1) (app recur t2) (app recur l))


### PR DESCRIPTION
All our functions that operated on structures with unknown sizes were recursive. I changed most of them to be iterative instead, so no more stack overflows! I hope we will get a decent speedup from this change. I confirmed that we can run benchmarks that create tuples types with 1k nodes and cast them easily without stack overflow segfaults. Furthermore, this PR paves the way to lift the definition of these functions to their natural home, `interpret-cast` pass.